### PR TITLE
Wait until image exists.

### DIFF
--- a/src/light-stemcell-builder/driver/create_ami_driver.go
+++ b/src/light-stemcell-builder/driver/create_ami_driver.go
@@ -78,6 +78,14 @@ func (d *SDKCreateAmiDriver) Create(driverConfig resources.AmiDriverConfig) (res
 		return resources.Ami{}, errors.New("AMI id nil")
 	}
 
+	d.logger.Printf("waiting for AMI: %s to exist\n", *amiIDptr)
+	err = d.ec2Client.WaitUntilImageExists(&ec2.DescribeImagesInput{
+		ImageIds: []*string{amiIDptr},
+	})
+	if err != nil {
+		return resources.Ami{}, fmt.Errorf("waiting for AMI %s to exist: %s", *amiIDptr, err)
+	}
+
 	d.logger.Printf("waiting for AMI: %s to be available\n", *amiIDptr)
 	err = d.ec2Client.WaitUntilImageAvailable(&ec2.DescribeImagesInput{
 		ImageIds: []*string{amiIDptr},


### PR DESCRIPTION
 In our experience, checking for AMI availability breaks many of our builds on GovCloud--there can be a brief delay between registering an AMI and the AMI existing via the API, so many builds fail with `InvalidAMIID.NotFound`. Adding a wait on AMI existence first resolves this issue for us.

Have you all encountered this kind of issue?
