### PR TITLE
Add missing action to example policy.

### DIFF
--- a/iam-policy.json
+++ b/iam-policy.json
@@ -55,6 +55,7 @@
         "ec2:ImportSnapshot",
         "ec2:ImportVolume",
         "ec2:ModifyImageAttribute",
+        "ec2:ModifySnapshotAttribute",
         "ec2:RegisterImage",
         "ec2:StartInstances",
         "ec2:StopInstances",


### PR DESCRIPTION
Looks like this is necessary after https://github.com/cloudfoundry-incubator/aws-light-stemcell-builder/commit/78f58f76a039990fbf6ad06c31f8a648b159571c.