### PR TITLE
Add support for ip tagged workers

### DIFF
--- a/ci/tasks/build.sh
+++ b/ci/tasks/build.sh
@@ -14,8 +14,9 @@ ami_server_side_encryption=${ami_server_side_encryption:-}
 : ${ami_virtualization_type:?}
 : ${ami_visibility:?}
 : ${ami_region:?}
-: ${ami_access_key:?}
-: ${ami_secret_key:?}
+: ${ami_credentials_source:?}
+: ${ami_access_key:-}
+: ${ami_secret_key:-}
 : ${ami_bucket_name:?}
 : ${ami_encrypted:?}
 
@@ -51,12 +52,13 @@ cat > $CONFIG_PATH << EOF
     {
       "name":               "$ami_region",
       "credentials": {
-        "access_key":       "$ami_access_key",
-        "secret_key":       "$ami_secret_key"
+        "credentials_source": "$ami_credentials_source",
+        "access_key":         "$ami_access_key",
+        "secret_key":         "$ami_secret_key"
       },
-      "bucket_name":        "$ami_bucket_name",
+      "bucket_name":            "$ami_bucket_name",
       "server_side_encryption": "$ami_server_side_encryption",
-      "destinations":       $ami_destinations
+      "destinations":           $ami_destinations
     }
   ]
 }

--- a/src/light-stemcell-builder/config/config.go
+++ b/src/light-stemcell-builder/config/config.go
@@ -48,9 +48,10 @@ type AmiRegion struct {
 }
 
 type Credentials struct {
-	AccessKey string `json:"access_key"`
-	SecretKey string `json:"secret_key"`
-	Region    string `json:"-"`
+	CredentialsSource string `json:"credentials_source"`
+	AccessKey         string `json:"access_key"`
+	SecretKey         string `json:"secret_key"`
+	Region            string `json:"-"`
 }
 
 type Config struct {

--- a/src/light-stemcell-builder/config/config.go
+++ b/src/light-stemcell-builder/config/config.go
@@ -146,7 +146,7 @@ func (r *AmiRegion) validate() error {
 		return errors.New("bucket_name must be specified for ami_regions entries")
 	}
 
-	if r.Credentials.CredentialsSource	== "static" {
+	if r.Credentials.CredentialsSource == "static" {
 		if r.Credentials.AccessKey == "" {
 			return errors.New("access_key must be specified for credentials")
 		}
@@ -154,12 +154,12 @@ func (r *AmiRegion) validate() error {
 		if r.Credentials.SecretKey == "" {
 			return errors.New("secret_key must be specified for credentials")
 		}
-	} 
+	}
 
 	/*
-	if r.Credentials.CredentialsSource == "" {
-		return errors.New("CredentialsSource must be specified as one of 'static', or 'env-or-profile'")
-	}
+		if r.Credentials.CredentialsSource == "" {
+			return errors.New("CredentialsSource must be specified as one of 'static', or 'env-or-profile'")
+		}
 	*/
 
 	if r.Credentials.Region == "" {

--- a/src/light-stemcell-builder/config/config.go
+++ b/src/light-stemcell-builder/config/config.go
@@ -146,12 +146,18 @@ func (r *AmiRegion) validate() error {
 		return errors.New("bucket_name must be specified for ami_regions entries")
 	}
 
-	if r.Credentials.AccessKey == "" {
-		return errors.New("access_key must be specified for credentials")
-	}
+	if r.Credentials.CredentialsSource	== "static" {
+		if r.Credentials.AccessKey == "" {
+			return errors.New("access_key must be specified for credentials")
+		}
 
-	if r.Credentials.SecretKey == "" {
-		return errors.New("secret_key must be specified for credentials")
+		if r.Credentials.SecretKey == "" {
+			return errors.New("secret_key must be specified for credentials")
+		}
+	} 
+
+	if r.Credentials.CredentialsSource == "" {
+		return errors.New("CredentialsSource must be specified as one of 'static', or 'env-or-profile'")
 	}
 
 	if r.Credentials.Region == "" {

--- a/src/light-stemcell-builder/config/config.go
+++ b/src/light-stemcell-builder/config/config.go
@@ -156,9 +156,11 @@ func (r *AmiRegion) validate() error {
 		}
 	} 
 
+	/*
 	if r.Credentials.CredentialsSource == "" {
 		return errors.New("CredentialsSource must be specified as one of 'static', or 'env-or-profile'")
 	}
+	*/
 
 	if r.Credentials.Region == "" {
 		return errors.New("region must be specified for credentials")

--- a/src/light-stemcell-builder/config/config_test.go
+++ b/src/light-stemcell-builder/config/config_test.go
@@ -40,6 +40,7 @@ var _ = Describe("Config", func() {
           "name": "ami-region",
           "bucket_name": "ami-bucket",
           "credentials": {
+            "credentials_source": "static",
             "access_key": "access-key",
             "secret_key": "secret-key"
           }

--- a/src/light-stemcell-builder/driver/copy_ami_driver.go
+++ b/src/light-stemcell-builder/driver/copy_ami_driver.go
@@ -34,9 +34,12 @@ func (d *SDKCopyAmiDriver) Create(driverConfig resources.AmiDriverConfig) (resou
 	dstRegion := driverConfig.DestinationRegion
 
 	awsConfig := aws.NewConfig().
-		WithCredentials(credentials.NewStaticCredentials(d.creds.AccessKey, d.creds.SecretKey, "")).
 		WithRegion(dstRegion).
 		WithLogger(newDriverLogger(d.logger))
+
+	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(d.creds.AccessKey, d.creds.SecretKey, ""))
+	}
 
 	ec2Client := ec2.New(session.New(), awsConfig)
 

--- a/src/light-stemcell-builder/driver/copy_ami_driver.go
+++ b/src/light-stemcell-builder/driver/copy_ami_driver.go
@@ -37,7 +37,7 @@ func (d *SDKCopyAmiDriver) Create(driverConfig resources.AmiDriverConfig) (resou
 		WithRegion(dstRegion).
 		WithLogger(newDriverLogger(d.logger))
 
-	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+	if d.creds.CredentialsSource == "static" {
 		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(d.creds.AccessKey, d.creds.SecretKey, ""))
 	}
 

--- a/src/light-stemcell-builder/driver/copy_ami_driver_test.go
+++ b/src/light-stemcell-builder/driver/copy_ami_driver_test.go
@@ -19,10 +19,8 @@ import (
 var _ = Describe("CopyAmiDriver", func() {
 	cpiAmi := func(encrypted bool, kmsKey string, cb ...func(*ec2.EC2, *ec2.DescribeImagesOutput)) {
 		accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
-		Expect(accessKey).ToNot(BeEmpty(), "AWS_ACCESS_KEY_ID must be set")
 
 		secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
-		Expect(secretKey).ToNot(BeEmpty(), "AWS_SECRET_ACCESS_KEY must be set")
 
 		region := os.Getenv("AWS_REGION")
 		Expect(region).ToNot(BeEmpty(), "AWS_REGION must be set")

--- a/src/light-stemcell-builder/driver/create_ami_driver.go
+++ b/src/light-stemcell-builder/driver/create_ami_driver.go
@@ -38,7 +38,7 @@ func NewCreateAmiDriver(logDest io.Writer, creds config.Credentials) *SDKCreateA
 		WithRegion(creds.Region).
 		WithLogger(newDriverLogger(logger))
 
-	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+	if creds.CredentialsSource == "static" {
 		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, ""))
 	}
 

--- a/src/light-stemcell-builder/driver/create_ami_driver.go
+++ b/src/light-stemcell-builder/driver/create_ami_driver.go
@@ -35,9 +35,12 @@ type SDKCreateAmiDriver struct {
 func NewCreateAmiDriver(logDest io.Writer, creds config.Credentials) *SDKCreateAmiDriver {
 	logger := log.New(logDest, "SDKCreateAmiDriver ", log.LstdFlags)
 	awsConfig := aws.NewConfig().
-		WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, "")).
 		WithRegion(creds.Region).
 		WithLogger(newDriverLogger(logger))
+
+	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, ""))
+	}
 
 	ec2Client := ec2.New(session.New(), awsConfig)
 	return &SDKCreateAmiDriver{ec2Client: ec2Client, region: creds.Region, logger: logger}

--- a/src/light-stemcell-builder/driver/create_ami_driver_test.go
+++ b/src/light-stemcell-builder/driver/create_ami_driver_test.go
@@ -24,10 +24,8 @@ var _ = Describe("CreateAmiDriver", func() {
 		logger := log.New(GinkgoWriter, "CreateAmiDriver - Bootable HVM Test: ", log.LstdFlags)
 
 		accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
-		Expect(accessKey).ToNot(BeEmpty(), "AWS_ACCESS_KEY_ID must be set")
 
 		secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
-		Expect(secretKey).ToNot(BeEmpty(), "AWS_SECRET_ACCESS_KEY must be set")
 
 		region := os.Getenv("AWS_REGION")
 		Expect(region).ToNot(BeEmpty(), "AWS_REGION must be set")
@@ -113,10 +111,8 @@ var _ = Describe("CreateAmiDriver", func() {
 		logger := log.New(GinkgoWriter, "CreateAmiDriver - Bootable PV Test: ", log.LstdFlags)
 
 		accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
-		Expect(accessKey).ToNot(BeEmpty(), "AWS_ACCESS_KEY_ID must be set")
 
 		secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
-		Expect(secretKey).ToNot(BeEmpty(), "AWS_SECRET_ACCESS_KEY must be set")
 
 		region := os.Getenv("AWS_REGION")
 		Expect(region).ToNot(BeEmpty(), "AWS_REGION must be set")

--- a/src/light-stemcell-builder/driver/create_machine_image_driver.go
+++ b/src/light-stemcell-builder/driver/create_machine_image_driver.go
@@ -30,9 +30,8 @@ func NewCreateMachineImageDriver(logDest io.Writer, creds config.Credentials) *S
 		WithRegion(creds.Region).
 		WithLogger(newDriverLogger(logger))
 
-	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+	if creds.CredentialsSource == "static" {
 		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, ""))
-
 	}
 
 	s3Retryer := S3Retryer{}

--- a/src/light-stemcell-builder/driver/create_machine_image_driver.go
+++ b/src/light-stemcell-builder/driver/create_machine_image_driver.go
@@ -27,9 +27,13 @@ func NewCreateMachineImageDriver(logDest io.Writer, creds config.Credentials) *S
 	logger := log.New(logDest, "SDKCreateMachineImageDriver ", log.LstdFlags)
 
 	awsConfig := aws.NewConfig().
-		WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, "")).
 		WithRegion(creds.Region).
 		WithLogger(newDriverLogger(logger))
+
+	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, ""))
+
+	}
 
 	s3Retryer := S3Retryer{}
 	s3Retryer.NumMaxRetries = 50

--- a/src/light-stemcell-builder/driver/create_machine_image_manifest_driver.go
+++ b/src/light-stemcell-builder/driver/create_machine_image_manifest_driver.go
@@ -35,9 +35,12 @@ func NewCreateMachineImageManifestDriver(logDest io.Writer, creds config.Credent
 	logger := log.New(logDest, "SDKCreateMachineImageManifestDriver ", log.LstdFlags)
 
 	awsConfig := aws.NewConfig().
-		WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, "")).
 		WithRegion(creds.Region).
 		WithLogger(newDriverLogger(logger))
+
+	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, ""))
+	}
 
 	s3Retryer := S3Retryer{}
 	s3Retryer.NumMaxRetries = 50

--- a/src/light-stemcell-builder/driver/create_machine_image_manifest_driver.go
+++ b/src/light-stemcell-builder/driver/create_machine_image_manifest_driver.go
@@ -38,7 +38,7 @@ func NewCreateMachineImageManifestDriver(logDest io.Writer, creds config.Credent
 		WithRegion(creds.Region).
 		WithLogger(newDriverLogger(logger))
 
-	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+	if creds.CredentialsSource == "static" {
 		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, ""))
 	}
 

--- a/src/light-stemcell-builder/driver/create_volume_driver.go
+++ b/src/light-stemcell-builder/driver/create_volume_driver.go
@@ -86,6 +86,9 @@ func (d *SDKCreateVolumeDriver) Create(driverConfig resources.VolumeDriverConfig
 		return resources.Volume{}, fmt.Errorf("deserializing import volume manifest. Bytes:\n%s\nError: %s", manifestBytes, err)
 	}
 
+	fmt.Println("=== SLEEPING FOR MANUAL DEBUGGING ===")
+	time.Sleep(5 * time.Minute)
+
 	reqOutput, err := d.ec2Client.ImportVolume(&ec2.ImportVolumeInput{
 		AvailabilityZone: availabilityZone,
 		Image: &ec2.DiskImageDetail{

--- a/src/light-stemcell-builder/driver/create_volume_driver.go
+++ b/src/light-stemcell-builder/driver/create_volume_driver.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/private/waiter"
 	"github.com/aws/aws-sdk-go/service/ec2"
+        "github.com/aws/aws-sdk-go/aws/awserr"
 )
 
 // SDKCreateVolumeDriver is an implementation of the resources VolumeDriver that
@@ -87,7 +88,7 @@ func (d *SDKCreateVolumeDriver) Create(driverConfig resources.VolumeDriverConfig
 	}
 
 	fmt.Println("=== SLEEPING FOR MANUAL DEBUGGING ===")
-	time.Sleep(5 * time.Minute)
+	// time.Sleep(5 * time.Minute)
 
 	reqOutput, err := d.ec2Client.ImportVolume(&ec2.ImportVolumeInput{
 		AvailabilityZone: availabilityZone,
@@ -102,8 +103,9 @@ func (d *SDKCreateVolumeDriver) Create(driverConfig resources.VolumeDriverConfig
 	})
 
 	if err != nil {
-		d.logger.Printf("Error Code/Message: %s %s", err.Code(), err.Message())
-		d.logger.Printf("Error: %s %s", err.Error())
+		aerr, ok := err.(awserr.Error)
+		d.logger.Printf("Error Code/Message: %s %s", aerr.Code(),a err.Message())
+		d.logger.Printf("Error: %s %s", aerr.Error())
 
 		return resources.Volume{}, fmt.Errorf("creating import volume task: %s", err)
 	}

--- a/src/light-stemcell-builder/driver/create_volume_driver.go
+++ b/src/light-stemcell-builder/driver/create_volume_driver.go
@@ -88,7 +88,7 @@ func (d *SDKCreateVolumeDriver) Create(driverConfig resources.VolumeDriverConfig
 	}
 
 	fmt.Println("=== SLEEPING FOR MANUAL DEBUGGING ===")
-	// time.Sleep(5 * time.Minute)
+	time.Sleep(5 * time.Minute)
 
 	reqOutput, err := d.ec2Client.ImportVolume(&ec2.ImportVolumeInput{
 		AvailabilityZone: availabilityZone,

--- a/src/light-stemcell-builder/driver/create_volume_driver.go
+++ b/src/light-stemcell-builder/driver/create_volume_driver.go
@@ -30,9 +30,12 @@ type SDKCreateVolumeDriver struct {
 func NewCreateVolumeDriver(logDest io.Writer, creds config.Credentials) *SDKCreateVolumeDriver {
 	logger := log.New(logDest, "SDKCreateVolumeDriver ", log.LstdFlags)
 	awsConfig := aws.NewConfig().
-		WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, "")).
 		WithRegion(creds.Region).
 		WithLogger(newDriverLogger(logger))
+
+	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, ""))
+	}
 
 	ec2Client := ec2.New(session.New(), awsConfig)
 	return &SDKCreateVolumeDriver{ec2Client: ec2Client, logger: logger}

--- a/src/light-stemcell-builder/driver/create_volume_driver.go
+++ b/src/light-stemcell-builder/driver/create_volume_driver.go
@@ -104,8 +104,8 @@ func (d *SDKCreateVolumeDriver) Create(driverConfig resources.VolumeDriverConfig
 
 	if err != nil {
 		aerr, ok := err.(awserr.Error)
-		d.logger.Printf("Error Code/Message: %s %s", aerr.Code(),a err.Message())
-		d.logger.Printf("Error: %s %s", aerr.Error())
+		d.logger.Printf("Error Code/Message: %s %s", aerr.Code(), aerr.Message())
+		d.logger.Printf("Error: %s", aerr.Error())
 
 		return resources.Volume{}, fmt.Errorf("creating import volume task: %s", err)
 	}

--- a/src/light-stemcell-builder/driver/create_volume_driver.go
+++ b/src/light-stemcell-builder/driver/create_volume_driver.go
@@ -102,6 +102,9 @@ func (d *SDKCreateVolumeDriver) Create(driverConfig resources.VolumeDriverConfig
 	})
 
 	if err != nil {
+		d.logger.Printf("Error Code/Message: %s %s", err.Code(), err.Message())
+		d.logger.Printf("Error: %s %s", err.Error())
+
 		return resources.Volume{}, fmt.Errorf("creating import volume task: %s", err)
 	}
 

--- a/src/light-stemcell-builder/driver/create_volume_driver.go
+++ b/src/light-stemcell-builder/driver/create_volume_driver.go
@@ -103,7 +103,7 @@ func (d *SDKCreateVolumeDriver) Create(driverConfig resources.VolumeDriverConfig
 	})
 
 	if err != nil {
-		aerr, ok := err.(awserr.Error)
+		aerr, _ := err.(awserr.Error)
 		d.logger.Printf("Error Code/Message: %s %s", aerr.Code(), aerr.Message())
 		d.logger.Printf("Error: %s", aerr.Error())
 

--- a/src/light-stemcell-builder/driver/create_volume_driver.go
+++ b/src/light-stemcell-builder/driver/create_volume_driver.go
@@ -33,7 +33,7 @@ func NewCreateVolumeDriver(logDest io.Writer, creds config.Credentials) *SDKCrea
 		WithRegion(creds.Region).
 		WithLogger(newDriverLogger(logger))
 
-	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+	if creds.CredentialsSource == "static" {
 		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, ""))
 	}
 

--- a/src/light-stemcell-builder/driver/delete_machine_image_driver.go
+++ b/src/light-stemcell-builder/driver/delete_machine_image_driver.go
@@ -31,7 +31,7 @@ func NewDeleteMachineImageDriver(logDest io.Writer, creds config.Credentials) *S
 		WithRegion(creds.Region).
 		WithLogger(newDriverLogger(logger))
 
-	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+	if creds.CredentialsSource == "static" {
 		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, ""))
 	}
 

--- a/src/light-stemcell-builder/driver/delete_machine_image_driver.go
+++ b/src/light-stemcell-builder/driver/delete_machine_image_driver.go
@@ -28,9 +28,12 @@ func NewDeleteMachineImageDriver(logDest io.Writer, creds config.Credentials) *S
 	logger := log.New(logDest, "SDKDeleteMachineImageDriver ", log.LstdFlags)
 
 	awsConfig := aws.NewConfig().
-		WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, "")).
 		WithRegion(creds.Region).
 		WithLogger(newDriverLogger(logger))
+
+	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, ""))
+	}
 
 	s3Session := session.New(awsConfig)
 	s3Client := s3.New(s3Session)

--- a/src/light-stemcell-builder/driver/delete_volume_driver.go
+++ b/src/light-stemcell-builder/driver/delete_volume_driver.go
@@ -26,7 +26,7 @@ func NewDeleteVolumeDriver(logDest io.Writer, creds config.Credentials) *SDKDele
 		WithRegion(creds.Region).
 		WithLogger(newDriverLogger(logger))
 
-	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+	if creds.CredentialsSource == "static" {
 		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, ""))
 	}
 

--- a/src/light-stemcell-builder/driver/delete_volume_driver.go
+++ b/src/light-stemcell-builder/driver/delete_volume_driver.go
@@ -23,9 +23,12 @@ type SDKDeleteVolumeDriver struct {
 func NewDeleteVolumeDriver(logDest io.Writer, creds config.Credentials) *SDKDeleteVolumeDriver {
 	logger := log.New(logDest, "SDKDeleteVolumeDriver ", log.LstdFlags)
 	awsConfig := aws.NewConfig().
-		WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, "")).
 		WithRegion(creds.Region).
 		WithLogger(newDriverLogger(logger))
+
+	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, ""))
+	}
 
 	ec2Client := ec2.New(session.New(), awsConfig)
 	return &SDKDeleteVolumeDriver{ec2Client: ec2Client, logger: logger}

--- a/src/light-stemcell-builder/driver/machine_image_lifecycle_test.go
+++ b/src/light-stemcell-builder/driver/machine_image_lifecycle_test.go
@@ -33,10 +33,8 @@ var _ = Describe("Machine Image Lifecycle", func() {
 
 	BeforeEach(func() {
 		accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
-		Expect(accessKey).ToNot(BeEmpty(), "AWS_ACCESS_KEY_ID must be set")
 
 		secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
-		Expect(secretKey).ToNot(BeEmpty(), "AWS_SECRET_ACCESS_KEY must be set")
 
 		region := os.Getenv("AWS_REGION")
 		Expect(region).ToNot(BeEmpty(), "AWS_REGION must be set")

--- a/src/light-stemcell-builder/driver/snapshot_from_image_driver.go
+++ b/src/light-stemcell-builder/driver/snapshot_from_image_driver.go
@@ -30,7 +30,7 @@ func NewSnapshotFromImageDriver(logDest io.Writer, creds config.Credentials) *SD
 		WithRegion(creds.Region).
 		WithLogger(newDriverLogger(logger))
 
-	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+	if creds.CredentialsSource == "static" {
 		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, ""))
 	}
 

--- a/src/light-stemcell-builder/driver/snapshot_from_image_driver.go
+++ b/src/light-stemcell-builder/driver/snapshot_from_image_driver.go
@@ -27,9 +27,12 @@ type SDKSnapshotFromImageDriver struct {
 func NewSnapshotFromImageDriver(logDest io.Writer, creds config.Credentials) *SDKSnapshotFromImageDriver {
 	logger := log.New(logDest, "SDKSnapshotFromImageDriver ", log.LstdFlags)
 	awsConfig := aws.NewConfig().
-		WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, "")).
 		WithRegion(creds.Region).
 		WithLogger(newDriverLogger(logger))
+
+	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, ""))
+	}
 
 	ec2Client := ec2.New(session.New(), awsConfig)
 	return &SDKSnapshotFromImageDriver{ec2Client: ec2Client, logger: logger}

--- a/src/light-stemcell-builder/driver/snapshot_from_image_driver_test.go
+++ b/src/light-stemcell-builder/driver/snapshot_from_image_driver_test.go
@@ -16,10 +16,8 @@ import (
 var _ = Describe("SnapshotFromImageDriver", func() {
 	It("creates a public snapshot from a machine image located at some S3 URL", func() {
 		accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
-		Expect(accessKey).ToNot(BeEmpty(), "AWS_ACCESS_KEY_ID must be set")
 
 		secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
-		Expect(secretKey).ToNot(BeEmpty(), "AWS_SECRET_ACCESS_KEY must be set")
 
 		region := os.Getenv("AWS_REGION")
 		Expect(region).ToNot(BeEmpty(), "AWS_REGION must be set")

--- a/src/light-stemcell-builder/driver/snapshot_from_volume_driver.go
+++ b/src/light-stemcell-builder/driver/snapshot_from_volume_driver.go
@@ -30,7 +30,7 @@ func NewSnapshotFromVolumeDriver(logDest io.Writer, creds config.Credentials) *S
 		WithRegion(creds.Region).
 		WithLogger(newDriverLogger(logger))
 
-	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+	if creds.CredentialsSource == "static" {
 		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, ""))
 	}
 

--- a/src/light-stemcell-builder/driver/snapshot_from_volume_driver.go
+++ b/src/light-stemcell-builder/driver/snapshot_from_volume_driver.go
@@ -27,9 +27,12 @@ type SDKSnapshotFromVolumeDriver struct {
 func NewSnapshotFromVolumeDriver(logDest io.Writer, creds config.Credentials) *SDKSnapshotFromVolumeDriver {
 	logger := log.New(logDest, "SDKSnapshotFromVolumeDriver ", log.LstdFlags)
 	awsConfig := aws.NewConfig().
-		WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, "")).
 		WithRegion(creds.Region).
 		WithLogger(newDriverLogger(logger))
+
+	if d.creds.AccessKey != "" && d.creds.SecretKey != "" {
+		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(creds.AccessKey, creds.SecretKey, ""))
+	}
 
 	ec2Client := ec2.New(session.New(), awsConfig)
 	return &SDKSnapshotFromVolumeDriver{ec2Client: ec2Client, logger: logger}

--- a/src/light-stemcell-builder/driver/snapshot_from_volume_driver_test.go
+++ b/src/light-stemcell-builder/driver/snapshot_from_volume_driver_test.go
@@ -16,10 +16,8 @@ import (
 var _ = Describe("SnapshotFromVolumeDriver", func() {
 	It("creates a public snapshot from an existing EBS volume", func() {
 		accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
-		Expect(accessKey).ToNot(BeEmpty(), "AWS_ACCESS_KEY_ID must be set")
 
 		secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
-		Expect(secretKey).ToNot(BeEmpty(), "AWS_SECRET_ACCESS_KEY must be set")
 
 		region := os.Getenv("AWS_REGION")
 		Expect(region).ToNot(BeEmpty(), "AWS_REGION must be set")

--- a/src/light-stemcell-builder/driver/volume_driver_lifecycle_test.go
+++ b/src/light-stemcell-builder/driver/volume_driver_lifecycle_test.go
@@ -17,10 +17,8 @@ import (
 var _ = Describe("Volume Driver Lifecycle", func() {
 	It("creates and deletes an EBS Volume from a previously uploaded machine image", func() {
 		accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
-		Expect(accessKey).ToNot(BeEmpty(), "AWS_ACCESS_KEY_ID must be set")
 
 		secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
-		Expect(secretKey).ToNot(BeEmpty(), "AWS_SECRET_ACCESS_KEY must be set")
 
 		region := os.Getenv("AWS_REGION")
 		Expect(region).ToNot(BeEmpty(), "AWS_REGION must be set")


### PR DESCRIPTION
Tied to the feature work on #14 and 18F/cg-deploy-aws-light-stemcell-builder#10.

The idea here is to only configure the AWS SDK if the credentials exist and to also remove the `notEmpty` calls from the driver tests.