### PR TITLE
Build AMIs with a meaningful name

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -83,6 +83,7 @@ shared:
       builder-src: cn-builder-src
     output_mapping: {light-stemcell: cn-light-stemcell}
     params:
+      publisher_name: {{publisher_name}}
       ami_description: {{publish__ami_description}}
       ami_encrypted: {{publish__ami_encrypted}}
       ami_kms_key_id: {{publish__ami_kms_key_id}}
@@ -102,6 +103,7 @@ shared:
       builder-src: us_gov-builder-src
     output_mapping: {light-stemcell: us_gov-light-stemcell}
     params:
+      publisher_name: {{publisher_name}}
       ami_description: {{publish__ami_description}}
       ami_encrypted: {{publish__ami_encrypted}}
       ami_kms_key_id: {{publish__ami_kms_key_id}}
@@ -121,6 +123,7 @@ shared:
       builder-src: us-builder-src
     output_mapping: {light-stemcell: us-light-stemcell}
     params:
+      publisher_name: {{publisher_name}}
       ami_description: {{publish__ami_description}}
       ami_encrypted: {{publish__ami_encrypted}}
       ami_kms_key_id: {{publish__ami_kms_key_id}}
@@ -138,6 +141,7 @@ shared:
       input-stemcell: us-input-stemcell
       builder-src: us-builder-src
     params:
+      publisher_name: {{publisher_name}}
       ami_description: {{publish_alpha__ami_description}}
       ami_encrypted: {{publish_alpha__ami_encrypted}}
       ami_kms_key_id: {{publish_alpha__ami_kms_key_id}}

--- a/ci/tasks/build.sh
+++ b/ci/tasks/build.sh
@@ -77,10 +77,15 @@ disk_size_gb=$(mb_to_gb "${BASH_REMATCH[1]}")
 [[ "${manifest_contents}" =~ ${format_regex} ]]
 disk_format="${BASH_REMATCH[1]}"
 
+stemcell_name=$(grep '^name: ' ${stemcell_manifest} | awk '{print $2}' | tr -d "\"'")
+stemcell_version=$(grep '^version: ' ${stemcell_manifest} | awk '{print $2}' | tr -d "\"'")
+ami_name="${stemcell_name}/${stemcell_version} from ${publisher_name:-unknown}"
+
 config_path=${PWD}/config.json
 cat > ${config_path} << EOF
 {
   "ami_configuration": {
+    "name":                 "$ami_name",
     "description":          "$ami_description",
     "virtualization_type":  "$ami_virtualization_type",
     "encrypted":            $ami_encrypted,

--- a/ci/tasks/build.yml
+++ b/ci/tasks/build.yml
@@ -15,6 +15,7 @@ run:
   path: builder-src/ci/tasks/build.sh
 params:
   bosh_io_bucket_name:        "bosh-aws-light-stemcells"
+  publisher_name:             ""
   ami_description:            ""
   ami_virtualization_type:    ""
   ami_visibility:             ""


### PR DESCRIPTION
Because I think it makes much more sense to see `bosh-aws-xen-hvm-ubuntu-trusty-go_agent/3468.11 from bosh-cpi` than `BOSH-e731bf31-319a-474c-aa8d-3017fcf8b014`.

<img width="646" alt="screen shot 2017-12-05 at 6 21 17 am" src="https://user-images.githubusercontent.com/207601/33612251-deb1d43e-d985-11e7-9e95-55c611336e48.png">

I added a `publisher_name` to the pipeline because I thought it might be important to disambiguate between light stemcells produced by different pipelines/teams. The previous UUID wasn't really useful, but it made it very unlikely for there to be overlap between AMIs produced elsewhere or for people to accidentally derive the origin of an AMI.

Maybe someday name could be a friendly URL pointing to the stemcell release version instead.