### PR TITLE
Prevent publishing ebs snapshots of private AMIs

### DIFF
--- a/driver/snapshot_from_image_driver.go
+++ b/driver/snapshot_from_image_driver.go
@@ -77,18 +77,20 @@ func (d *SDKSnapshotFromImageDriver) Create(driverConfig resources.SnapshotDrive
 
 	d.logger.Printf("created snapshot %s\n", *snapshotIDptr)
 
-	modifySnapshotAttributeInput := &ec2.ModifySnapshotAttributeInput{
-		SnapshotId:    snapshotIDptr,
-		Attribute:     aws.String("createVolumePermission"),
-		OperationType: aws.String("add"),
-		GroupNames:    []*string{aws.String("all")},
-	}
-	_, err = d.ec2Client.ModifySnapshotAttribute(modifySnapshotAttributeInput)
-	if err != nil {
-		return resources.Snapshot{}, fmt.Errorf("making snapshot with id %s public: %s", *snapshotIDptr, err)
-	}
+	if driverConfig.Accessibility == resources.PublicAmiAccessibility {
+		modifySnapshotAttributeInput := &ec2.ModifySnapshotAttributeInput{
+			SnapshotId:    snapshotIDptr,
+			Attribute:     aws.String("createVolumePermission"),
+			OperationType: aws.String("add"),
+			GroupNames:    []*string{aws.String("all")},
+		}
+		_, err = d.ec2Client.ModifySnapshotAttribute(modifySnapshotAttributeInput)
+		if err != nil {
+			return resources.Snapshot{}, fmt.Errorf("making snapshot with id %s public: %s", *snapshotIDptr, err)
+		}
 
-	d.logger.Printf("snapshot %s is public\n", *snapshotIDptr)
+		d.logger.Printf("snapshot %s is public\n", *snapshotIDptr)
+	}
 
 	return resources.Snapshot{ID: *snapshotIDptr}, nil
 }

--- a/driver/snapshot_from_image_driver_test.go
+++ b/driver/snapshot_from_image_driver_test.go
@@ -47,4 +47,39 @@ var _ = Describe("SnapshotFromImageDriver", func() {
 		})
 		Expect(err).To(BeNil())
 	})
+
+	It("skips modifying the snapshot privacy for a private machine image", func() {
+		driverConfig := resources.SnapshotDriverConfig{
+			MachineImageURL: s3MachineImageUrl,
+			FileFormat:      s3MachineImageFormat,
+		}
+
+		ds := driverset.NewStandardRegionDriverSet(GinkgoWriter, creds)
+		driver := ds.CreateSnapshotDriver()
+
+		snapshot, err := driver.Create(driverConfig)
+		Expect(err).ToNot(HaveOccurred())
+
+		awsSession, err := session.NewSession(creds.GetAwsConfig())
+		Expect(err).ToNot(HaveOccurred())
+		ec2Client := ec2.New(awsSession)
+
+		reqOutput, err := ec2Client.DescribeSnapshots(&ec2.DescribeSnapshotsInput{SnapshotIds: []*string{&snapshot.ID}})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(len(reqOutput.Snapshots)).To(Equal(1))
+
+		snapshotAttributes, err := ec2Client.DescribeSnapshotAttribute(&ec2.DescribeSnapshotAttributeInput{
+			SnapshotId: aws.String(snapshot.ID),
+			Attribute:  aws.String("createVolumePermission"),
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(snapshotAttributes.CreateVolumePermissions)).To(Equal(0))
+
+		//cleanup
+		_, err = ec2Client.DeleteSnapshot(&ec2.DeleteSnapshotInput{
+			SnapshotId: aws.String(snapshot.ID),
+		})
+		Expect(err).To(BeNil())
+	})
 })

--- a/publisher/standard_region.go
+++ b/publisher/standard_region.go
@@ -69,6 +69,7 @@ func (p *StandardRegionPublisher) Publish(ds driverset.StandardRegionDriverSet, 
 	snapshotDriverConfig := resources.SnapshotDriverConfig{
 		MachineImageURL: machineImage.GetURL,
 		FileFormat:      machineImageConfig.FileFormat,
+		AmiProperties:   p.AmiProperties,
 	}
 
 	snapshotDriver := ds.CreateSnapshotDriver()

--- a/publisher/standard_region_test.go
+++ b/publisher/standard_region_test.go
@@ -103,6 +103,7 @@ var _ = Describe("StandardRegionPublisher", func() {
 		Expect(fakeSnapshotDriver.CreateArgsForCall(0)).To(Equal(resources.SnapshotDriverConfig{
 			MachineImageURL: fakeMachineImageURL,
 			FileFormat:      resources.VolumeRawFormat,
+			AmiProperties:   fakeAmiProperties,
 		}))
 
 		Expect(fakeDs.CreateAmiDriverCallCount()).To(Equal(1), "Expected Driverset.CreateAmiDriver to be called once")

--- a/resources/snapshot.go
+++ b/resources/snapshot.go
@@ -18,4 +18,5 @@ type SnapshotDriverConfig struct {
 
 	MachineImageURL string
 	FileFormat      string
+	AmiProperties
 }


### PR DESCRIPTION
Hi we'd like to use the light-stemcellbuilder for the private FIPS stemcells.
Currently this is impossible for multiple reasons. One is that the light-stemcell-builder is always publishing a snapshot. 

With this PR we prevent publishing the EBS Snapthot if the later produced AMI is not public