### PR TITLE
Enable cross account sharing of private AMIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-.idea
-config.json
+.idea/
+local/
+light-stemcell-builder

--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ type AmiConfiguration struct {
 	KmsKeyAliasName    string            `json:"kms_key_alias_name"`
 	Visibility         string            `json:"visibility"`
 	Tags               map[string]string `json:"tags,omitempty"`
+	SharedWithAccounts []string          `json:"shared_with_accounts"`
 }
 
 type AmiRegion struct {

--- a/driver/driver_suite_test.go
+++ b/driver/driver_suite_test.go
@@ -22,6 +22,8 @@ var s3MachineImageUrl, s3MachineImageFormat string
 
 var kmsKeyId string
 
+var awsAccount string
+
 var amiFixtureID string
 
 func TestDrivers(t *testing.T) {
@@ -71,6 +73,9 @@ var _ = SynchronizedBeforeSuite(
 		// KMS Key info
 		kmsKeyId = os.Getenv("AWS_KMS_KEY_ID")
 		Expect(kmsKeyId).ToNot(BeEmpty(), "AWS_KMS_KEY_ID must be set")
+
+		awsAccount = os.Getenv("AWS_ACCOUNT")
+		Expect(awsAccount).ToNot(BeEmpty(), "AWS_ACCOUNT must be set")
 	},
 )
 

--- a/publisher/standard_region.go
+++ b/publisher/standard_region.go
@@ -36,6 +36,7 @@ func NewStandardRegionPublisher(logDest io.Writer, c Config) *StandardRegionPubl
 			KmsKeyId:           c.KmsKeyId,
 			KmsKeyAliasName:    c.KmsKeyAliasName,
 			Tags:               c.Tags,
+			SharedWithAccounts: c.SharedWithAccounts,
 		},
 		logger: log.New(logDest, "StandardRegionPublisher ", log.LstdFlags),
 	}

--- a/resources/ami.go
+++ b/resources/ami.go
@@ -36,6 +36,7 @@ type AmiProperties struct {
 	KmsKeyAliasName    string
 	KmsKeyAlias        string
 	Tags               map[string]string
+	SharedWithAccounts []string
 }
 
 // AmiDriverConfig allows an AmiDriver to create an AMI from either a snapshot ID or an existing AMI (copy)


### PR DESCRIPTION
For private AMIs like FIPS stemcells one has to explicitly configure
the accounts that can launch instances of such private AMIs.