### PR TITLE
AWS Stemcells: only use account sharing...

### DIFF
--- a/driver/copy_ami_driver_test.go
+++ b/driver/copy_ami_driver_test.go
@@ -90,6 +90,13 @@ func copyAmi(encrypted bool, kmsKeyId string, cb ...func(*ec2.EC2, *ec2.Describe
 		accessibility = resources.PrivateAmiAccessibility
 	}
 
+	var sharedWithAccounts []string
+	if kmsKeyId != "" {
+		sharedWithAccounts = []string{awsAccount}
+	} else {
+		sharedWithAccounts = []string{}
+	}
+
 	amiDriverConfig := resources.AmiDriverConfig{
 		ExistingAmiID:     amiFixtureID,
 		DestinationRegion: destinationRegion,
@@ -100,7 +107,7 @@ func copyAmi(encrypted bool, kmsKeyId string, cb ...func(*ec2.EC2, *ec2.Describe
 			Accessibility:      accessibility,
 			Encrypted:          encrypted,
 			KmsKeyId:           kmsKeyId,
-			SharedWithAccounts: []string{awsAccount},
+			SharedWithAccounts: sharedWithAccounts,
 		},
 	}
 

--- a/driver/kms_driver.go
+++ b/driver/kms_driver.go
@@ -87,7 +87,10 @@ func (d *SDKKmsDriver) ReplicateKey(driverConfig resources.KmsReplicateKeyDriver
 		d.logger.Printf("Completed ReplicateKey() in %f minutes\n", time.Since(startTime).Minutes())
 	}(createStartTime)
 
-	d.logger.Printf("Replicating kms key: %s\n", driverConfig.KmsKeyId)
+	d.logger.Printf("Replicating kms key: %s from region %s to region %s\n",
+		driverConfig.KmsKeyId,
+		driverConfig.SourceRegion,
+		driverConfig.TargetRegion)
 	_, err := d.createKmsClient(driverConfig.SourceRegion).ReplicateKey(&kms.ReplicateKeyInput{
 		KeyId:         &driverConfig.KmsKeyId,
 		ReplicaRegion: &driverConfig.TargetRegion,


### PR DESCRIPTION
...for tests that use a KMS key.

This reduces the number of failures found in https://github.com/cloudfoundry/bosh-aws-light-stemcell-builder/pull/31