### PR TITLE
Loudly error when failing to make an AMI public

### DIFF
--- a/driver/copy_ami_driver.go
+++ b/driver/copy_ami_driver.go
@@ -128,7 +128,7 @@ func (d *SDKCopyAmiDriver) Create(driverConfig resources.AmiDriverConfig) (resou
 
 	if driverConfig.Accessibility == resources.PublicAmiAccessibility {
 		d.logger.Printf("making AMI: %s public", *amiIDptr)
-		_, err = ec2Client.ModifyImageAttribute(&ec2.ModifyImageAttributeInput{ //nolint:errcheck
+		_, err = ec2Client.ModifyImageAttribute(&ec2.ModifyImageAttributeInput{
 			ImageId: amiIDptr,
 			LaunchPermission: &ec2.LaunchPermissionModifications{
 				Add: []*ec2.LaunchPermission{

--- a/driver/copy_ami_driver.go
+++ b/driver/copy_ami_driver.go
@@ -128,7 +128,7 @@ func (d *SDKCopyAmiDriver) Create(driverConfig resources.AmiDriverConfig) (resou
 
 	if driverConfig.Accessibility == resources.PublicAmiAccessibility {
 		d.logger.Printf("making AMI: %s public", *amiIDptr)
-		ec2Client.ModifyImageAttribute(&ec2.ModifyImageAttributeInput{ //nolint:errcheck
+		_, err = ec2Client.ModifyImageAttribute(&ec2.ModifyImageAttributeInput{ //nolint:errcheck
 			ImageId: amiIDptr,
 			LaunchPermission: &ec2.LaunchPermissionModifications{
 				Add: []*ec2.LaunchPermission{
@@ -138,6 +138,9 @@ func (d *SDKCopyAmiDriver) Create(driverConfig resources.AmiDriverConfig) (resou
 				},
 			},
 		})
+		if err != nil {
+			return resources.Ami{}, fmt.Errorf("failed to make AMI '%s' public: %w", *amiIDptr, err)
+		}
 	}
 
 	if driverConfig.Encrypted {


### PR DESCRIPTION
We published a light stemcell (Jammy 1.406) whose AMI in region `eu-central-1` was not public, causing an error when a user tried to deploy.

The problem was we never checked to make sure that our attempt to make the AMI public succeeded.

With this commit, we now propagate any errors that occur when attempting to make the AMI we publish public.

Signed-off-by: Brian Cunnie <brian.cunnie@broadcom.com>

[#184045754] Ensure the aws light stemcell builder catches errors when making AMIs public

The test attempts to make an encrypted snapshot public when copying, which triggers the error, "failed to make AMI 'ami-0957311dac7d2f6fe' public: UnsupportedOperation: Encrypted snapshots can't be shared publicly. Specify another snapshot.\n\tstatus code: 400".