### PR TITLE
Share the snapshots of private stemcells

### DIFF
--- a/driver/copy_ami_driver.go
+++ b/driver/copy_ami_driver.go
@@ -217,6 +217,21 @@ func (d *SDKCopyAmiDriver) Create(driverConfig resources.AmiDriverConfig) (resou
 		d.logger.Printf("Error tagging Snapshot: %s, Error: %s ", *snapshotIDptr, err.Error())
 	}
 
+	for _, account := range driverConfig.SharedWithAccounts {
+		modifySnapshotAttributeInput := &ec2.ModifySnapshotAttributeInput{
+			SnapshotId:    snapshotIDptr,
+			Attribute:     aws.String("createVolumePermission"),
+			OperationType: aws.String("add"),
+			UserIds: []*string{
+				aws.String(account),
+			},
+		}
+		_, err = ec2Client.ModifySnapshotAttribute(modifySnapshotAttributeInput)
+		if err != nil {
+			return resources.Ami{}, fmt.Errorf("sharing snapshot with id %s with account %s: %v", *snapshotIDptr, account, err)
+		}
+	}
+
 	if driverConfig.Encrypted {
 		return resources.Ami{ID: *amiIDptr, Region: dstRegion}, nil
 	}

--- a/driver/copy_ami_driver.go
+++ b/driver/copy_ami_driver.go
@@ -143,10 +143,6 @@ func (d *SDKCopyAmiDriver) Create(driverConfig resources.AmiDriverConfig) (resou
 		}
 	}
 
-	if driverConfig.Encrypted {
-		return resources.Ami{ID: *amiIDptr, Region: dstRegion}, nil
-	}
-
 	var snapshotIDptr *string
 	var snapshotErr error
 
@@ -219,6 +215,10 @@ func (d *SDKCopyAmiDriver) Create(driverConfig resources.AmiDriverConfig) (resou
 	_, err = ec2Client.CreateTags(tags)
 	if err != nil {
 		d.logger.Printf("Error tagging Snapshot: %s, Error: %s ", *snapshotIDptr, err.Error())
+	}
+
+	if driverConfig.Encrypted {
+		return resources.Ami{ID: *amiIDptr, Region: dstRegion}, nil
 	}
 
 	modifySnapshotAttributeInput := &ec2.ModifySnapshotAttributeInput{

--- a/driver/create_ami_driver.go
+++ b/driver/create_ami_driver.go
@@ -153,6 +153,19 @@ func (d *SDKCreateAmiDriver) Create(driverConfig resources.AmiDriverConfig) (res
 		if err != nil {
 			return resources.Ami{}, fmt.Errorf("failed to share AMI '%s' with account '%s': %w", *amiIDptr, account, err)
 		}
+
+		modifySnapshotAttributeInput := &ec2.ModifySnapshotAttributeInput{
+			SnapshotId:    aws.String(driverConfig.SnapshotID),
+			Attribute:     aws.String("createVolumePermission"),
+			OperationType: aws.String("add"),
+			UserIds: []*string{
+				aws.String(account),
+			},
+		}
+		_, err = d.ec2Client.ModifySnapshotAttribute(modifySnapshotAttributeInput)
+		if err != nil {
+			return resources.Ami{}, fmt.Errorf("sharing snapshot with id %s with account %s: %v", driverConfig.SnapshotID, account, err)
+		}
 	}
 
 	d.logger.Printf("waiting for AMI: %s to be available\n", *amiIDptr)


### PR DESCRIPTION
There is currently a bug for shared stemcells. AWS changed the behaviour by copy AMIs to other regions.
The new default is that they only share the AMI now. The snapshot is not shared. As bosh need the snapshot to create it's own AMI, we must share this as well.
With this PR we share the snapshot with the configured accounts and tag them correctly.