### PR TITLE
Add endpoint_base support for non-standard AWS partitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-## Light Stemcell Builder for AWS
+# Light Stemcell Builder for AWS
 
 This tool takes a raw machine image and a configuration file and creates a collection of AMIs.
 Any AWS region including China is supported.
 
-#### AWS Setup for Publishing
+## AWS Setup for Publishing
 
 1. Create an S3 bucket for intermediate artifacts (e.g. `light-stemcells-for-project-XXX`)
 1. Create an AWS IAM policy based on the JSON contained in `builder-policy.json`
 1. Replace the bucket placeholder in your policy with the bucket created in step 1
+
     ```diff
       "Resource": [
     -    "arn:aws:s3:::<disk-image-file-bucket>",
@@ -16,29 +17,32 @@ Any AWS region including China is supported.
     +    "arn:aws:s3:::light-stemcells-for-project-XXX/*"
       ]
     ```
+
     Note: The arn for AWS GovCloud region is `aws-us-gov`. It looks like this: `"arn:aws-us-gov:s3:::<disk-image-file-bucket>"`
 1. Create an AWS IAM user and attach the policy created in steps 2, 3.
 1. Create the `vmimport` AWS role as detailed [here](https://web.archive.org/web/20181210011548/https://docs.aws.amazon.com/vm-import/latest/userguide/vmimport-image-import.html#import-image-prereqs), specifying the previously created bucket in place of `<disk-image-file-bucket>`; see [example IAM policy](iam-policy.json).
-  1. Updated docs are split over [vm-import](https://docs.aws.amazon.com/vm-import/latest/userguide/vmimport-image-import.html) and [roles](https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#vmimport-role) now.
+    - Updated docs are split over [vm-import](https://docs.aws.amazon.com/vm-import/latest/userguide/vmimport-image-import.html) and [roles](https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#vmimport-role) now.
 1. Replicate these steps in a separate AWS China account if publishing to China.
 
-#### IAM User Setup for Integration Testing
+## IAM User Setup for Integration Testing
 
 1. Follow steps in "AWS Setup for Publishing"
 1. Create an IAM policy based on the JSON contained in `integration-test-policy.json`
 1. Attach the policy you created in step 2 to the existing publishing user
 
-#### Testing
+## Testing
 
 Unit testing:
-```
+
+```shell
 ginkgo -r --skipPackage driver,integration
 ```
 
-#### Example Usage
+## Example Usage
 
 Example config:
-```
+
+```json
 {
   "ami_configuration": {
     "description":          "Your description here",
@@ -71,13 +75,39 @@ Example config:
 }
 ```
 
-Usage:
+### Non-standard AWS partitions (custom endpoint domain)
+
+Some AWS partitions use a different endpoint domain than the default `amazonaws.com`. For example, the AWS EU Sovereign Cloud (EUSC) uses `amazonaws.eu`.
+
+Set `endpoint_base` on the region entry to override the endpoint domain for all services (EC2, S3, KMS):
+
+```json
+{
+  "ami_regions": [
+    {
+      "name":           "eusc-de-east-1",
+      "endpoint_base":  "amazonaws.eu",
+      "credentials": {
+        "access_key":   "ACCESS_KEY_ID",
+        "secret_key":   "ACCESS_SECRET_KEY"
+      },
+      "bucket_name":    "BUCKET_NAME"
+    }
+  ]
+}
 ```
+
+Service endpoints are constructed as `https://<service>.<region>.<endpoint_base>`, e.g. `https://ec2.eusc-de-east-1.amazonaws.eu`.
+
+Usage:
+
+```shell
 ./light-stemcell-builder -c config.json --image root.img --manifest stemcell.MF > updated-stemcell.MF
 ```
 
 Example Output:
-```
+
+```yml
 name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
 version: "3202"
 bosh_protocol: "1"
@@ -93,9 +123,9 @@ cloud_properties:
     us-west-2: ami-54328238
 ```
 
-#### Troubleshooting
+## Troubleshooting
 
 If the `vmimport` role is not present, you will receive this error from the light stemcell builder:
 
-> Error publishing AMIs to us-east-1: creating snapshot: creating import snapshot task: InvalidParameter: The sevice role <vmimport> does not exist or does not have sufficient permissions for the service to continue
-	status code: 400, request id:
+> Error publishing AMIs to us-east-1: creating snapshot: creating import snapshot task: InvalidParameter: The sevice role <vmimport> does not exist or does not have sufficient permissions for the service to continue<br>
+> status code: 400, request id:

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	uuid "github.com/satori/go.uuid"
 )
@@ -84,6 +85,11 @@ type AmiRegion struct {
 	Destinations []string `json:"destinations"`
 
 	IsolatedRegion bool `json:"-"`
+
+	// EndpointBase allows to override the default AWS endpoint domain for regions
+	// that use a non-standard domain (e.g. "amazonaws.eu" for EUSC regions).
+	// Service endpoints are constructed as https://<service>.<region>.<endpoint_base>
+	EndpointBase string `json:"endpoint_base"`
 }
 
 type Credentials struct {
@@ -92,6 +98,7 @@ type Credentials struct {
 	SessionToken string `json:"session_token"`
 	RoleArn      string `json:"role_arn"`
 	Region       string `json:"-"`
+	EndpointBase string `json:"-"`
 }
 
 type Config struct {
@@ -135,6 +142,7 @@ func NewFromReader(r io.Reader) (Config, error) {
 	for i := range c.AmiRegions {
 		region := &c.AmiRegions[i]
 		region.Credentials.Region = region.RegionName
+		region.Credentials.EndpointBase = region.EndpointBase
 		region.IsolatedRegion = isolated[region.RegionName]
 	}
 
@@ -233,6 +241,23 @@ func (configCredentials *Credentials) GetAwsConfig() *aws.Config {
 			session.Must(session.NewSession(awsCfg)),
 			configCredentials.RoleArn,
 		)
+	}
+
+	if configCredentials.EndpointBase != "" {
+		endpointBase := configCredentials.EndpointBase
+		region := configCredentials.Region
+		defaultResolver := endpoints.DefaultResolver()
+		awsCfg = awsCfg.WithEndpointResolver(endpoints.ResolverFunc(
+			func(service, reg string, opts ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+				if reg != region {
+					return defaultResolver.EndpointFor(service, reg, opts...)
+				}
+				return endpoints.ResolvedEndpoint{
+					URL:           fmt.Sprintf("https://%s.%s.%s", service, reg, endpointBase),
+					SigningRegion: reg,
+				}, nil
+			},
+		))
 	}
 
 	return awsCfg

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -327,5 +327,69 @@ var _ = Describe("Config", func() {
 				Expect(*awsCfg.Region).To(Equal("eu-west-1"))
 			})
 		})
+
+		Context("when endpoint_base is not set", func() {
+			It("does not set a custom endpoint resolver", func() {
+				creds := config.Credentials{
+					AccessKey: keyID,
+					SecretKey: keyValue,
+					Region:    region,
+				}
+
+				awsCfg := creds.GetAwsConfig()
+
+				Expect(awsCfg.EndpointResolver).To(BeNil())
+			})
+		})
+
+		Context("when endpoint_base is set", func() {
+			It("resolves unknown regions using the custom endpoint base", func() {
+				creds := config.Credentials{
+					AccessKey:    keyID,
+					SecretKey:    keyValue,
+					Region:       "eusc-de-east-1",
+					EndpointBase: "amazonaws.eu",
+				}
+
+				awsCfg := creds.GetAwsConfig()
+
+				Expect(awsCfg.EndpointResolver).NotTo(BeNil())
+				ep, err := awsCfg.EndpointResolver.EndpointFor("ec2", "eusc-de-east-1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ep.URL).To(Equal("https://ec2.eusc-de-east-1.amazonaws.eu"))
+				Expect(ep.SigningRegion).To(Equal("eusc-de-east-1"))
+			})
+
+			It("falls back to the default resolver for other regions", func() {
+				creds := config.Credentials{
+					AccessKey:    keyID,
+					SecretKey:    keyValue,
+					Region:       "eusc-de-east-1",
+					EndpointBase: "amazonaws.eu",
+				}
+
+				awsCfg := creds.GetAwsConfig()
+
+				Expect(awsCfg.EndpointResolver).NotTo(BeNil())
+				ep, err := awsCfg.EndpointResolver.EndpointFor("ec2", "us-east-1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ep.URL).To(ContainSubstring("amazonaws.com"))
+			})
+
+			It("uses the custom endpoint for whatever region is set — destination credentials must not inherit endpoint_base", func() {
+				destinationCreds := config.Credentials{
+					AccessKey:    keyID,
+					SecretKey:    keyValue,
+					Region:       "us-east-1",
+					EndpointBase: "amazonaws.eu", // wrongly inherited
+				}
+
+				awsCfg := destinationCreds.GetAwsConfig()
+
+				ep, err := awsCfg.EndpointResolver.EndpointFor("ec2", "us-east-1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ep.URL).To(Equal("https://ec2.us-east-1.amazonaws.eu"))
+			})
+		})
 	})
 })


### PR DESCRIPTION
Adds an optional `endpoint_base` field to `ami_regions` config entries, enabling support for AWS partitions that use a non-standard endpoint domain (e.g. AWS EU Sovereign Cloud with amazonaws.eu).

When set, a custom endpoint resolver is registered on the AWS config that routes calls for the configured region to `https://<service>.<region>.<endpoint_base>`, while all other regions (e.g. copy destinations) continue to use the default AWS resolver.

Following [[RFC] Account for AWS European Sovereign Cloud](https://github.com/cloudfoundry/community/pull/1441).
